### PR TITLE
Add OIDC auth support

### DIFF
--- a/dcacheclient/client.py
+++ b/dcacheclient/client.py
@@ -5,6 +5,7 @@ dCache client library.
 import requests
 import logging
 
+from dcacheclient import oidc
 from dcacheclient.api.v1 import alarms
 from dcacheclient.api.v1 import billing
 from dcacheclient.api.v1 import cells
@@ -31,7 +32,7 @@ class Client(object):
     def __init__(self, url, session=None, username=None, password=None, certificate=None,
                  private_key=None, x509_proxy=None, no_check_certificate=True,
                  ca_certificate=None, ca_directory=None, timeout=None,
-                 version="v1"):
+                 oidc_agent_account=None, version="v1"):
         """
         :param string url: A user-supplied endpoint URL for the dCache service.
                            http(s)://$HOST:$PORT/
@@ -50,6 +51,7 @@ class Client(object):
         :param ca_certificate: CA certificate to verify peer against (SSL).
         :param ca_directory: CA directory to verify peer against (SSL).
         :param timeout: socket read timeout value, passed directly to the requests library.
+        :param oidc_agent_account: the oidc-agent account name from which to get the access token.
         :param string version: The version of API to use.
         """
         self.url = url
@@ -69,6 +71,9 @@ class Client(object):
             if self.username and self.password:
                 LOGGER.debug('HTTP basic authentication: %s' % (self.username))
                 self.session.auth = (self.username + '#admin', self.password)
+
+            if oidc_agent_account:
+                self.session.auth = oidc.OidcAuth(oidc_agent_account)
 
             if self.certificate and self.private_key:
                 LOGGER.debug('HTTPS X.509 grid authentication: (%s,%s)' % (self.certificate, self.private_key))

--- a/dcacheclient/dcache_admin.py
+++ b/dcacheclient/dcache_admin.py
@@ -64,7 +64,8 @@ def get_client(args):
         no_check_certificate=args.no_check_certificate,
         ca_certificate=args.ca_certificate,
         ca_directory=args.ca_directory,
-        timeout=args.timeout)
+        timeout=args.timeout,
+        oidc_agent_account=args.oidc_agent_account)
     try:
         yield dcache
     except Exception:
@@ -933,6 +934,14 @@ def get_parser(config):
         '--x509_proxy', dest='x509_proxy',
         nargs='?', const=os.environ.get('X509_USER_PROXY', '/tmp/x509up_u' + str(os.getuid())),
         help='Client X509 proxy file.')
+
+    # Options for OIDC
+    oparser.add_argument(
+        '--oidc-agent-account',
+        metavar="ACCOUNT",
+        dest='oidc_agent_account',
+        default=config.get('default', 'oidc-agent-account', fallback=None),
+        help='The name of the oidc-agent account to use when authenticating with dCache')
 
     oparser.set_defaults(func=oparser.print_help)
 

--- a/dcacheclient/oidc.py
+++ b/dcacheclient/oidc.py
@@ -1,0 +1,12 @@
+import requests
+import liboidcagent as oidc
+
+class OidcAuth(requests.auth.AuthBase):
+    """Support for authenticating with OIDC access token"""
+    def __init__(self, account):
+        self.account = account
+
+    def __call__(self, r):
+        token = oidc.get_access_token(self.account)
+        r.headers.update({'Authorization': "Bearer {}".format(token)})
+        return r

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ REQUIRES = [
     "certifi",
     "python-dateutil",
     "argcomplete >= 1.9.4",
-    "sseclient"]
+    "sseclient",
+    "liboidcagent >= 0.2.2"]
 #    "rucio-clients"]
 
 setup(


### PR DESCRIPTION
This support uses oidc-agent.  Specifying the --oidc-agent-account
command-line option activates OIDC support.